### PR TITLE
Tweetボタンの実装とTwitter用のメタデータ編集

### DIFF
--- a/Melissa/Resource/Language/en-US.txt
+++ b/Melissa/Resource/Language/en-US.txt
@@ -66,3 +66,4 @@ countries: us
 "volume_balance" = "Music/Metronome volume balance"
 "volume_metronome" = "Metronome volume"
 "add_marker" = "Add marker"
+"twitter_share" = "Tweet"

--- a/Melissa/Resource/Language/ja-JP.txt
+++ b/Melissa/Resource/Language/ja-JP.txt
@@ -69,3 +69,4 @@ countries: ja
 "volume_balance" = "音楽/メトロノームのボリュームバランス"
 "volume_metronome" = "メトロノームのボリューム"
 "add_marker" = "マーカーを追加"
+"twitter_share" = "ツイートする"

--- a/Melissa/Source/MainComponent.cpp
+++ b/Melissa/Source/MainComponent.cpp
@@ -38,6 +38,7 @@ enum
     kMenuID_MainVersionCheck,
     kMenuID_MainPreferences,
     kMenuID_MainTutorial,
+    kMenuID_TwitterShare,
     kMenuID_FileOpen = 2000,
 };
 
@@ -275,6 +276,7 @@ void MainComponent::createUI()
         menu.addItem(kMenuID_Manual, TRANS("open_manual"));
         menu.addItem(kMenuID_MainVersionCheck, TRANS("check_update"));
         menu.addItem(kMenuID_MainPreferences, TRANS("preferences"));
+        menu.addItem(kMenuID_TwitterShare, TRANS("twitter_share"));
 #if defined(ENABLE_TUTORIAL)
         menu.addItem(kMenuID_MainTutorial, TRANS("tutorial"));
 #endif
@@ -299,6 +301,10 @@ void MainComponent::createUI()
         else if (result == kMenuID_MainTutorial)
         {
             showTutorial();
+        }
+        else if (result == kMenuID_TwitterShare)
+        {
+            URL("https://twitter.com/intent/tweet?&text=Melissa+-+%E6%A5%BD%E5%99%A8%E7%B7%B4%E7%BF%92%2F%E8%80%B3%E3%82%B3%E3%83%94%E7%94%A8%E3%81%AE%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%83%83%E3%82%AF%E3%83%97%E3%83%AC%E3%82%A4%E3%83%A4%E3%83%BC+%28macOS+%2F+Windows+%E5%AF%BE%E5%BF%9C%29&url=https%3A%2F%2Fmosynthkey.github.io%2FMelissa%2F&hashtags=MelissaMusicPlayer").launchInDefaultBrowser();
         }
     };
     addAndMakeVisible(menuButton_.get());

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,17 @@
     <!-- mobile specific metas
     ================================================== -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:description"
+        content="楽器練習をもっと効率的に、より楽しく。あなたの練習を強力にサポートします。反復練習のサポート 上達の鍵となる反復練習を効率的に行うことができます。音程を変えずに再生速度を変更することができます。リピートする範囲は波形を">
+    <meta property="twitter:title" content="Melissa - 楽器練習/耳コピ用のミュージックプレイヤー (macOS / Windows 対応)">
+    <meta property="twitter:url" content="https://mosynthkey.github.io/Melissa/">
+    <meta name="twitter:image" content="https://mosynthkey.github.io/Melissa/images/screenshot.png">
+    <meta name="twitter:domain" content="mosynthkey.github.io">
+    <meta name="twitter:creator" content="@Melissa__Player">
+    <meta name="twitter:site" content="@Melissa__Player">
+    <!-- /Twitter Card -->
     <!-- CSS
     ================================================== -->
     <link rel="stylesheet" href="css/base.css">


### PR DESCRIPTION
メニューボタンからツイートするボタンを追加。ボタンを押すとTwitterのツイート画面が表示される。
GitHubPagesのメタデータにTwitter Card用の情報を追加 Twitter上でサイト情報が表示される
#3 