### PR TITLE
Add Linux build with sufficient(-ish) Japanese font support.

### DIFF
--- a/Melissa/Melissa.jucer
+++ b/Melissa/Melissa.jucer
@@ -266,6 +266,27 @@
         <MODULEPATH id="juce_audio_basics" path="../../juce"/>
       </MODULEPATHS>
     </VS2019>
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_opengl" path="../../juce"/>
+        <MODULEPATH id="juce_gui_extra" path="../../juce"/>
+        <MODULEPATH id="juce_gui_basics" path="../../juce"/>
+        <MODULEPATH id="juce_graphics" path="../../juce"/>
+        <MODULEPATH id="juce_events" path="../../juce"/>
+        <MODULEPATH id="juce_data_structures" path="../../juce"/>
+        <MODULEPATH id="juce_cryptography" path="../../juce"/>
+        <MODULEPATH id="juce_core" path="../../juce"/>
+        <MODULEPATH id="juce_audio_utils" path="../../juce"/>
+        <MODULEPATH id="juce_audio_processors" path="../../juce"/>
+        <MODULEPATH id="juce_audio_formats" path="../../juce"/>
+        <MODULEPATH id="juce_audio_devices" path="../../juce"/>
+        <MODULEPATH id="juce_audio_basics" path="../../juce"/>
+      </MODULEPATHS>
+    </LINUX_MAKE>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
@@ -285,6 +306,7 @@
   <LIVE_SETTINGS>
     <OSX/>
     <WINDOWS/>
+    <LINUX/>
   </LIVE_SETTINGS>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_USE_MP3AUDIOFORMAT="1"
                JUCE_ASIO="1"/>

--- a/Melissa/Source/Audio/MelissaAudioEngine.h
+++ b/Melissa/Source/Audio/MelissaAudioEngine.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include "MelissaModelListener.h"
 #include "SoundTouch.h"
+#include <memory>
 
 class MelissaDataSource;
 class MelissaModel;

--- a/Melissa/Source/Audio/MelissaMetronome.h
+++ b/Melissa/Source/Audio/MelissaMetronome.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 #include "MelissaModelListener.h"
 
 class MelissaMetronome : public MelissaModelListener

--- a/Melissa/Source/UI/MelissaUISettings.cpp
+++ b/Melissa/Source/UI/MelissaUISettings.cpp
@@ -13,6 +13,10 @@ bool MelissaUISettings::isJa = false;
 bool MelissaUISettings::isMac = true;
 String MelissaUISettings::japaneseFontName_ = "YuGothic";
 String MelissaUISettings::latinFontName_    = "San Francisco";
+#elif defined(JUCE_LINUX)
+bool MelissaUISettings::isMac = false;
+String MelissaUISettings::japaneseFontName_ = "IPAGothic";
+String MelissaUISettings::latinFontName_    = "Verdana";
 
 #else
 bool MelissaUISettings::isMac = false;


### PR DESCRIPTION
This changeset brings in Linux build. It works quite flawlessly.

![image](https://user-images.githubusercontent.com/53929/94358702-e3874e80-00dd-11eb-9319-d6e659f43a7b.png)
